### PR TITLE
fix: support null input object

### DIFF
--- a/values.go
+++ b/values.go
@@ -154,6 +154,9 @@ func coerceValue(ttype Input, value interface{}) interface{} {
 		}
 		return append(values, coerceValue(ttype.OfType, value))
 	case *InputObject:
+		if isNullish(value) {
+			return nil
+		}
 		var obj = map[string]interface{}{}
 		valueMap, _ := value.(map[string]interface{})
 		if valueMap == nil {

--- a/values.go
+++ b/values.go
@@ -136,13 +136,13 @@ func getVariableValue(schema Schema, definitionAST *ast.VariableDefinition, inpu
 
 // Given a type and any value, return a runtime value coerced to match the type.
 func coerceValue(ttype Input, value interface{}) interface{} {
+	if isNullish(value) {
+		return nil
+	}
 	switch ttype := ttype.(type) {
 	case *NonNull:
 		return coerceValue(ttype.OfType, value)
 	case *List:
-		if isNullish(value) {
-			return nil
-		}
 		var values = []interface{}{}
 		valType := reflect.ValueOf(value)
 		if valType.Kind() == reflect.Slice {
@@ -154,9 +154,6 @@ func coerceValue(ttype Input, value interface{}) interface{} {
 		}
 		return append(values, coerceValue(ttype.OfType, value))
 	case *InputObject:
-		if isNullish(value) {
-			return nil
-		}
 		var obj = map[string]interface{}{}
 		valueMap, _ := value.(map[string]interface{})
 		if valueMap == nil {

--- a/values_test.go
+++ b/values_test.go
@@ -1,6 +1,9 @@
 package graphql
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestIsIterable(t *testing.T) {
 	if !isIterable([]int{}) {
@@ -14,5 +17,54 @@ func TestIsIterable(t *testing.T) {
 	}
 	if isIterable(nil) {
 		t.Fatal("expected isIterable to return false for nil, got true")
+	}
+}
+
+func Test_coerceValue(t *testing.T) {
+	t.Parallel()
+
+	type input struct {
+		ttype Input
+		value any
+	}
+	testCases := map[string]struct {
+		input    input
+		expected any
+	}{
+		"null Input Object is coerced to nil": {
+			input: input{
+				ttype: NewInputObject(InputObjectConfig{
+					Name: "InputObject",
+				}),
+				value: nil,
+			},
+			expected: nil,
+		},
+		"null field in Input Object is not omitted, and coerced to nil": {
+			input: input{
+				ttype: NewInputObject(InputObjectConfig{
+					Name: "InputObject",
+					Fields: InputObjectConfigFieldMap{
+						"string": &InputObjectFieldConfig{
+							Type: String,
+						},
+					},
+				}),
+				value: map[string]any{"string": nil},
+			},
+			expected: map[string]any{"string": nil},
+		},
+	}
+
+	for name, tc := range testCases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := coerceValue(tc.input.ttype, tc.input.value)
+			if !reflect.DeepEqual(tc.expected, got) {
+				t.Errorf("unexpected result, expected: %v, got: %v", tc.expected, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Issue

### TL; DR

Return nil instead of an empty map when a null input object is passed to `coerceValue`.

### Task summary / Change details
