### PR TITLE
feat: Support federation v2 directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,66 @@ func main() {
 	fmt.Printf("%s \n", rJSON) // {"data":{"hello":"world"}}
 }
 ```
+
+### Federation v2 Support
+
+This library supports GraphQL Federation v2 directives, including `@external` and `@extends`. Here's an example of how to use them:
+
+```go
+package main
+
+import (
+	"github.com/tailor-inc/graphql"
+)
+
+func main() {
+	// Define a type that extends a type from another service
+	userType := graphql.NewObject(graphql.ObjectConfig{
+		Name: "User",
+		Fields: graphql.Fields{
+			"id": &graphql.Field{
+				Type: graphql.NewNonNull(graphql.ID),
+				// This field is owned by another service
+				Directives: []*graphql.Directive{graphql.ExternalDirective},
+			},
+			"name": &graphql.Field{
+				Type: graphql.String,
+			},
+			"email": &graphql.Field{
+				Type: graphql.String,
+				// This field is also owned by another service
+				Directives: []*graphql.Directive{graphql.ExternalDirective},
+			},
+		},
+		// This type extends a type from another service
+		Directives: []*graphql.Directive{graphql.ExtendsDirective},
+	})
+
+	// Use Federation directives in your schema
+	schema, err := graphql.NewSchema(graphql.SchemaConfig{
+		Query: userType,
+		// Include Federation directives
+		Directives: append(graphql.SpecifiedDirectives, graphql.FederationDirectives...),
+	})
+	
+	if err != nil {
+		log.Fatalf("failed to create schema: %v", err)
+	}
+}
+```
+
+Available Federation v2 directives:
+- `@external` - Marks a field as owned by another service
+- `@extends` - Allows extending types from other services  
+- `@requires` - Specifies required fields for resolution
+- `@provides` - Specifies fields that will be provided
+- `@key` - Defines entity keys
+- `@shareable` - Allows fields to be resolved by multiple services
+- `@override` - Takes responsibility for a field from another service
+- `@inaccessible` - Marks fields as inaccessible to consumers
+- `@link` - Links to external schemas
+- `@composeDirective` - Preserves custom directives in supergraph
+
 For more complex examples, refer to the [examples/](https://github.com/tailor-inc/graphql/tree/master/examples/) directory and [graphql_test.go](https://github.com/tailor-inc/graphql/blob/master/graphql_test.go).
 
 ### Third Party Libraries

--- a/directives.go
+++ b/directives.go
@@ -34,6 +34,23 @@ var SpecifiedDirectives = []*Directive{
 	DeprecatedDirective,
 }
 
+// AllDirectives The full list of specified directives plus Federation directives.
+var AllDirectives = append(SpecifiedDirectives, FederationDirectives...)
+
+// FederationDirectives The full list of Federation v2 directives.
+var FederationDirectives = []*Directive{
+	ExternalDirective,
+	ExtendsDirective,
+	RequiresDirective,
+	ProvidesDirective,
+	KeyDirective,
+	LinkDirective,
+	ShareableDirective,
+	OverrideDirective,
+	InaccessibleDirective,
+	ComposeDirective,
+}
+
 // Directive structs are used by the GraphQL runtime as a way of modifying execution
 // behavior. Type system creators will usually not create these directly.
 type Directive struct {
@@ -147,12 +164,24 @@ var DeprecatedDirective = NewDirective(DirectiveConfig{
 	},
 })
 
-// ExternalDirective
-// directive @external on FIELD_DEFINITION
+// ExternalDirective The @external directive is used to mark a field as owned by another service.
+// This allows you to extend a type from another service without taking ownership of the field.
 var ExternalDirective = NewDirective(DirectiveConfig{
-	Name: "external",
+	Name:        "external",
+	Description: "The @external directive is used to mark a field as owned by another service. This allows you to extend a type from another service without taking ownership of the field.",
 	Locations: []string{
 		DirectiveLocationFieldDefinition,
+	},
+})
+
+// ExtendsDirective The @extends directive is used to represent type extensions in the schema.
+// It allows subgraphs to extend types defined in other subgraphs.
+var ExtendsDirective = NewDirective(DirectiveConfig{
+	Name:        "extends",
+	Description: "The @extends directive is used to represent type extensions in the schema. It allows subgraphs to extend types defined in other subgraphs.",
+	Locations: []string{
+		DirectiveLocationObject,
+		DirectiveLocationInterface,
 	},
 })
 

--- a/directives_test.go
+++ b/directives_test.go
@@ -514,3 +514,86 @@ func TestDirectivesWorksWithSkipAndIncludeDirectives_NoIncludeOrSkip(t *testing.
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
+
+func TestDirectives_ExternalDirective(t *testing.T) {
+	directive := graphql.ExternalDirective
+
+	if directive.Name != "external" {
+		t.Fatalf("Expected directive name to be 'external', got: %v", directive.Name)
+	}
+
+	expectedDescription := "The @external directive is used to mark a field as owned by another service. This allows you to extend a type from another service without taking ownership of the field."
+	if directive.Description != expectedDescription {
+		t.Fatalf("Expected directive description to match, got: %v", directive.Description)
+	}
+
+	expectedLocations := []string{graphql.DirectiveLocationFieldDefinition}
+	if len(directive.Locations) != len(expectedLocations) {
+		t.Fatalf("Expected %d locations, got: %d", len(expectedLocations), len(directive.Locations))
+	}
+
+	for i, location := range expectedLocations {
+		if directive.Locations[i] != location {
+			t.Fatalf("Expected location %d to be %v, got: %v", i, location, directive.Locations[i])
+		}
+	}
+
+	if len(directive.Args) != 0 {
+		t.Fatalf("Expected external directive to have no arguments, got: %d", len(directive.Args))
+	}
+}
+
+func TestDirectives_ExtendsDirective(t *testing.T) {
+	directive := graphql.ExtendsDirective
+
+	if directive.Name != "extends" {
+		t.Fatalf("Expected directive name to be 'extends', got: %v", directive.Name)
+	}
+
+	expectedDescription := "The @extends directive is used to represent type extensions in the schema. It allows subgraphs to extend types defined in other subgraphs."
+	if directive.Description != expectedDescription {
+		t.Fatalf("Expected directive description to match, got: %v", directive.Description)
+	}
+
+	expectedLocations := []string{graphql.DirectiveLocationObject, graphql.DirectiveLocationInterface}
+	if len(directive.Locations) != len(expectedLocations) {
+		t.Fatalf("Expected %d locations, got: %d", len(expectedLocations), len(directive.Locations))
+	}
+
+	for i, location := range expectedLocations {
+		if directive.Locations[i] != location {
+			t.Fatalf("Expected location %d to be %v, got: %v", i, location, directive.Locations[i])
+		}
+	}
+
+	if len(directive.Args) != 0 {
+		t.Fatalf("Expected extends directive to have no arguments, got: %d", len(directive.Args))
+	}
+}
+
+func TestDirectives_FederationDirectives(t *testing.T) {
+	directives := graphql.FederationDirectives
+
+	expectedCount := 10 // external, extends, requires, provides, key, link, shareable, override, inaccessible, composeDirective
+	if len(directives) != expectedCount {
+		t.Fatalf("Expected %d federation directives, got: %d", expectedCount, len(directives))
+	}
+
+	// Check that external and extends are included
+	var foundExternal, foundExtends bool
+	for _, directive := range directives {
+		if directive.Name == "external" {
+			foundExternal = true
+		}
+		if directive.Name == "extends" {
+			foundExtends = true
+		}
+	}
+
+	if !foundExternal {
+		t.Fatal("Expected external directive to be in FederationDirectives")
+	}
+	if !foundExtends {
+		t.Fatal("Expected extends directive to be in FederationDirectives")
+	}
+}


### PR DESCRIPTION
### Issue

Support federation v2 directives

### TL; DR

Available Federation v2 directives:
- `@external` - Marks a field as owned by another service
- `@extends` - Allows extending types from other services  
- `@requires` - Specifies required fields for resolution
- `@provides` - Specifies fields that will be provided
- `@key` - Defines entity keys
- `@shareable` - Allows fields to be resolved by multiple services
- `@override` - Takes responsibility for a field from another service
- `@inaccessible` - Marks fields as inaccessible to consumers
- `@link` - Links to external schemas
- `@composeDirective` - Preserves custom directives in supergraph

### Task summary / Change details

This pull request introduces GraphQL Federation v2 support to the library, adding new directives and enhancing schema capabilities. Key changes include the implementation of Federation v2 directives, updates to directive definitions, and extensive testing to ensure compatibility and correctness.

### Federation v2 Support:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R63-R122): Added documentation and examples for using Federation v2 directives, including `@external` and `@extends`.

### Directive Enhancements:
* [`directives.go`](diffhunk://#diff-02c303fd270c5524ae2ea05cba61c5a42398cc1ed8b51d27e5d57b567a7f7f53R37-R53): Defined `AllDirectives` and `FederationDirectives` variables to include Federation v2 directives. Added detailed descriptions for `@external` and `@extends` directives. [[1]](diffhunk://#diff-02c303fd270c5524ae2ea05cba61c5a42398cc1ed8b51d27e5d57b567a7f7f53R37-R53) [[2]](diffhunk://#diff-02c303fd270c5524ae2ea05cba61c5a42398cc1ed8b51d27e5d57b567a7f7f53L150-R187)

### Testing Improvements:
* [`directives_test.go`](diffhunk://#diff-11a38bf2f7669eeb23ec33b48f9f94551bb5635b535006a2ddf3fecc53cd7488R517-R599): Added tests for `@external` and `@extends` directives, verifying their names, descriptions, locations, and arguments. Also tested the inclusion of all Federation directives in `FederationDirectives`.
* [`sdl_parser_test.go`](diffhunk://#diff-3c25707e95c603a8445fe03c2efd30e7da120d7bd058444b81e8796addfe9ca1R168-R243): Added tests to ensure correct parsing of Federation directives and their usage in SDL, including validation of `@external` and `@extends` directives on fields and types.
