### PR TITLE
chore: update maintaner to team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Mistat @jackchuka @ikawaha @dragon3
+* @tailor-platform/maintainers-graphql


### PR DESCRIPTION
This pull request updates the code ownership configuration to assign all files to the `@tailor-platform/maintainers-graphql` team.

- Changed the global code owner in `.github/CODEOWNERS` from individual users to the `@tailor-platform/maintainers-graphql` team for better team-based ownership management.