### PR TITLE
feat(gqlerrors): support multiple errors from resolver via errors.Join

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -586,7 +586,7 @@ func handleFieldError(r interface{}, fieldNodes []ast.Node, path *ResponsePath, 
 	if _, ok := returnType.(*NonNull); ok {
 		panic(err)
 	}
-	eCtx.Errors = append(eCtx.Errors, gqlerrors.FormatError(err))
+	eCtx.Errors = append(eCtx.Errors, gqlerrors.FormatErrorsFromError(err)...)
 }
 
 // Resolves the field on the given source object. In particular, this


### PR DESCRIPTION
### Issue

N/A

### TL; DR

- Enable resolvers to return multiple GraphQL errors using `errors.Join`

### Task summary / Change details

- Add `FormatErrorsFromError` function in `gqlerrors/formatted.go` to expand joined errors
- Update `handleFieldError` in `executor.go` to use the new function
- Add tests for multiple errors and nested joined errors

**Usage:**
```go
func resolve(p graphql.ResolveParams) (interface{}, error) {
    err1 := errors.New("first error")
    err2 := errors.New("second error")
    return nil, errors.Join(err1, err2)
}
```

**Result:**
```json
{
  "errors": [
    {"message": "first error", "path": ["field"]},
    {"message": "second error", "path": ["field"]}
  ]
}
```

Backward compatible - single errors work as before.
