### PR TITLE
feat(gqlerrors): support custom path per error via PathError interface

### DIFF
--- a/gqlerrors/formatted.go
+++ b/gqlerrors/formatted.go
@@ -11,6 +11,11 @@ type ExtendedError interface {
 	Extensions() map[string]interface{}
 }
 
+type PathError interface {
+	error
+	Path() []interface{}
+}
+
 type FormattedError struct {
 	Message       string                    `json:"message"`
 	Locations     []location.SourceLocation `json:"locations"`
@@ -43,9 +48,12 @@ func FormatError(err error) FormattedError {
 			Path:          err.Path,
 			originalError: err,
 		}
-		if err := err.OriginalError; err != nil {
-			if extended, ok := err.(ExtendedError); ok {
+		if origErr := err.OriginalError; origErr != nil {
+			if extended, ok := origErr.(ExtendedError); ok {
 				ret.Extensions = extended.Extensions()
+			}
+			if pathErr, ok := origErr.(PathError); ok {
+				ret.Path = pathErr.Path()
 			}
 		}
 		return ret


### PR DESCRIPTION
### Issue

N/A

### TL; DR

- Enable errors to specify custom paths, overriding the default field path

### Task summary / Change details

- Add `PathError` interface in `gqlerrors/formatted.go`
- Update `FormatError` to check for `PathError` and use custom path
- Add tests for custom paths, combined with extensions, and multiple errors

**Usage:**
```go
type ValidationError struct {
    Msg       string
    FieldPath []interface{}
}

func (e *ValidationError) Error() string       { return e.Msg }
func (e *ValidationError) Path() []interface{} { return e.FieldPath }

func resolve(p graphql.ResolveParams) (interface{}, error) {
    return nil, &ValidationError{
        Msg:       "Name is required",
        FieldPath: []interface{}{"createUser", "input", "name"},
    }
}
```

**Result:**
```json
{
  "errors": [
    {"message": "Name is required", "path": ["createUser", "input", "name"]}
  ]
}
```

Backward compatible - errors without PathError work as before.
