### PR TITLE
fix(graphql): expand multiple errors for NonNull fields

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -54,7 +54,7 @@ func Execute(p ExecuteParams) (result *Result) {
 
 		defer func() {
 			if err := recover(); err != nil {
-				result.Errors = append(result.Errors, gqlerrors.FormatError(err.(error)))
+				result.Errors = append(result.Errors, gqlerrors.FormatErrorsFromError(err.(error))...)
 			}
 			resultChannel <- result
 		}()

--- a/executor_test.go
+++ b/executor_test.go
@@ -2471,6 +2471,49 @@ func TestQuery_NestedJoinedErrors(t *testing.T) {
 	}
 }
 
+func TestQuery_MultipleErrorsFromResolverNonNull(t *testing.T) {
+	queryType := graphql.NewObject(graphql.ObjectConfig{
+		Name: "Query",
+		Fields: graphql.Fields{
+			"value": &graphql.Field{
+				Type: graphql.NewNonNull(graphql.Int), // NonNull at top level
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					return nil, errors.Join(
+						errors.New("first error"),
+						errors.New("second error"),
+					)
+				},
+			},
+		},
+	})
+
+	schema, err := graphql.NewSchema(graphql.SchemaConfig{
+		Query: queryType,
+	})
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	result := graphql.Do(graphql.Params{
+		Schema:        schema,
+		RequestString: `{ value }`,
+	})
+
+	if len(result.Errors) != 2 {
+		t.Fatalf("expected 2 errors, got %d: %+v", len(result.Errors), result.Errors)
+	}
+
+	expectedMessages := []string{
+		"first error",
+		"second error",
+	}
+	for i, err := range result.Errors {
+		if err.Message != expectedMessages[i] {
+			t.Errorf("error[%d]: expected message %q, got %q", i, expectedMessages[i], err.Message)
+		}
+	}
+}
+
 type pathError struct {
 	msg  string
 	path []interface{}


### PR DESCRIPTION
### Issue

N/A

### TL; DR

- Fix multiple error expansion for NonNull fields

### Task summary / Change details

**Root cause:**
For NonNull fields, `handleFieldError` re-panics the error to propagate it to the parent (per GraphQL spec). This panic is caught in the `Execute` goroutine's defer block, which uses `FormatError()` instead of `FormatErrorsFromError()`.

**Solution:**
Changed `executor.go:57` to use `FormatErrorsFromError()`.
